### PR TITLE
.html: should be .svelte

### DIFF
--- a/src/content/guide/00-introduction.md
+++ b/src/content/guide/00-introduction.md
@@ -77,10 +77,10 @@ Within the `LayerCake` component, you'll want to add at least one layout compone
 
   // These are components that live in your project that
   // you can customize as you see fit
-  import ScatterCanvas from './components/ScatterCanvas.html';
-  import AxisX from './components/AxisX.html';
-  import AxisY from './components/AxisY.html';
-  import Annotations from './components/Annotations.html';
+  import ScatterCanvas from './components/ScatterCanvas.svelte';
+  import AxisX from './components/AxisX.svelte';
+  import AxisY from './components/AxisY.svelte';
+  import Annotations from './components/Annotations.svelte';
 
   // Set up some data
   const points = [


### PR DESCRIPTION
I think these should be .svelte.

BTW, if I try and copy paste said example into the starter template, the output is not exactly what I expected.

<img width="1086" alt="Screenshot 2020-04-26 at 13 15 10" src="https://user-images.githubusercontent.com/12690/80305880-07a5d300-87c0-11ea-8d9e-621b6e4380b3.png">
