### PR TITLE
Fix "Layout components" section example code

### DIFF
--- a/src/content/guide/00-introduction.md
+++ b/src/content/guide/00-introduction.md
@@ -77,10 +77,10 @@ Within the `LayerCake` component, you'll want to add at least one layout compone
 
   // These are components that live in your project that
   // you can customize as you see fit
-  import ScatterCanvas from './components/ScatterCanvas.html';
-  import AxisX from './components/AxisX.html';
-  import AxisY from './components/AxisY.html';
-  import Annotations from './components/Annotations.html';
+  import ScatterCanvas from './components/ScatterCanvas.svelte';
+  import AxisX from './components/AxisX.svelte';
+  import AxisY from './components/AxisY.svelte';
+  import Annotations from './components/Annotations.svelte';
 
   // Set up some data
   const points = [


### PR DESCRIPTION
When copy-paste this example code in the `App.svelte` from the repo https://github.com/mhkeller/layercake-template, I have got this error :
`Error: Could not resolve './components/ScatterCanvas.html' from src/App.svelte`

To make the code working in the demo project, `.html` extensions need to be replace `.svelte`